### PR TITLE
Fix streamlit bug "ModuleNotFoundError: No module named 'streamlit.report_thread'"

### DIFF
--- a/cartoon-stylegan/app.py
+++ b/cartoon-stylegan/app.py
@@ -5,7 +5,7 @@ import torch
 import utils
 
 import streamlit as st
-from streamlit.report_thread import REPORT_CONTEXT_ATTR_NAME
+from streamlit.script_run_context import SCRIPT_RUN_CONTEXT_ATTR_NAME
 
 from contextlib import contextmanager
 from threading import current_thread


### PR DESCRIPTION
Hello, I'm a fan of `Streamlit Tutorials`!

## Problem

* [Error importing hydralit: "ModuleNotFoundError: No module named 'streamlit.report_thread'"](https://stackoverflow.com/questions/70813915/error-importing-hydralit-modulenotfounderror-no-module-named-streamlit-repor)
    * Source: [cartoon-stylegan/app.py:8](https://github.com/happy-jihye/Streamlit-Tutorial/blob/277b83b8d60a29e5bdb8c1cd84646974030d267b/cartoon-stylegan/app.py#L8)

## Causes

* Renamed
    * Before: streamlit.report_thread.REPORT_CONTEXT_ATTR_NAME
    * After: streamlit.script_run_context.SCRIPT_RUN_CONTEXT_ATTR_NAME

## Solution

* Changed
    * Before: streamlit.report_thread.REPORT_CONTEXT_ATTR_NAME
    * After: streamlit.script_run_context.SCRIPT_RUN_CONTEXT_ATTR_NAME
